### PR TITLE
Setup an ELB for Káto workers

### DIFF
--- a/cmd/katoctl/cmd_ec2.go
+++ b/cmd/katoctl/cmd_ec2.go
@@ -313,4 +313,9 @@ var (
 		" [ true | false ]").
 		Default("true").OverrideDefaultFromEnvar("KATO_EC2_RUN_SOURCE_DEST_CHECK").
 		Enum("true", "false")
+
+	flEc2RunELBName = cmdEc2Run.Flag("elb-name",
+		"Register with existing ELB by name").
+		OverrideDefaultFromEnvar("KATO_EC2_RUN_ELB_NAME").
+		String()
 )

--- a/cmd/katoctl/katoctl.go
+++ b/cmd/katoctl/katoctl.go
@@ -223,6 +223,7 @@ func main() {
 				IAMRole:      *flEc2RunIAMRole,
 				SrcDstCheck:  *flEc2RunSrcDstCheck,
 				AmiID:        *flEc2RunAmiID,
+				ELBName:      *flEc2RunELBName,
 			},
 		}
 

--- a/providers/cloud/ec2/ec2.go
+++ b/providers/cloud/ec2/ec2.go
@@ -95,6 +95,7 @@ type State struct {
 	EdgeSecGrp       string  `json:"EdgeSecGrp"`       //             | ec2:setup |       |
 	IntSubnetID      string  `json:"IntSubnetID"`      //             | ec2:setup |       |
 	ExtSubnetID      string  `json:"ExtSubnetID"`      //             | ec2:setup |       |
+	DNSName          string  `json:"DNSName"`          //             | ec2:setup |       |
 	AllocationID     string  `json:"AllocationID"`     //             | ec2:setup |       | ec2:run
 	KeyPair          string  `json:"KeyPair"`          //             |           |       | ec2:run
 }
@@ -809,7 +810,11 @@ func (d *Data) setupEC2Balancer(wg *sync.WaitGroup) {
 		os.Exit(1)
 	}
 
-	log.Info(resp)
+	// Store the ELB DNS name:
+	d.DNSName = *resp.DNSName
+	log.WithFields(log.Fields{
+		"cmd": "ec2:" + d.command, "id": d.DNSName}).
+		Info("New ELB DNS name created")
 }
 
 //-----------------------------------------------------------------------------

--- a/udata/udata.go
+++ b/udata/udata.go
@@ -140,7 +140,7 @@ func (d *Data) Render() error {
 	// Apply parsed template to data object:
 	if d.GzipUdata {
 		log.WithFields(log.Fields{"cmd": "udata", "id": d.Role + "-" + d.HostID}).
-			Info("- Rendering gzipped cloud-config template")
+			Info("Rendering gzipped cloud-config template")
 		w := gzip.NewWriter(os.Stdout)
 		if err = t.Execute(w, d); err != nil {
 			log.WithField("cmd", "udata").Error(err)
@@ -149,7 +149,7 @@ func (d *Data) Render() error {
 		}
 		_ = w.Close()
 	} else {
-		log.WithField("cmd", "udata").Info("- Rendering plain text cloud-config template")
+		log.WithField("cmd", "udata").Info("Rendering plain text cloud-config template")
 		if err = t.Execute(os.Stdout, d); err != nil {
 			log.WithField("cmd", "udata").Error(err)
 			return err


### PR DESCRIPTION
Workers listen on TCP ports 80 and 443.